### PR TITLE
fix: Fix Gemini broken CDATA delimiters

### DIFF
--- a/navie/extract_changes.py
+++ b/navie/extract_changes.py
@@ -22,6 +22,9 @@ class FileUpdate:
 
 
 def extract_changes(content: str) -> List[FileUpdate]:
+    # Gemini tends to use ``` instead of closing CDATA properly.
+    content = content.replace("```</", "]]></")
+
     # Search for <change> tags
     change_regex = re.compile(r"<change>([\s\S]*?)<\/change>", re.IGNORECASE)
     changes: List[FileUpdate] = []

--- a/test/test_extract_changes.py
+++ b/test/test_extract_changes.py
@@ -1,4 +1,4 @@
-from typing import List
+from textwrap import dedent
 from navie.extract_changes import (
     extract_changes,
     FileUpdate,
@@ -18,6 +18,31 @@ def test_extract_changes_valid():
             file="example.py",
             search='print("Hello, World!")',
             modified='print("Hello, Universe!")',
+        )
+    ]
+    result = extract_changes(content)
+    assert result == expected
+
+
+def test_extract_changes_invalid_cdata():
+    content = dedent(
+        """\
+        <change>
+        <file>example.py</file>
+        <original><![CDATA[
+            print("Hello, World!")
+        ```</original>
+        <modified><![CDATA[
+            print("Hello, Universe!")
+        ```</modified>
+        </change>
+    """
+    )
+    expected = [
+        FileUpdate(
+            file="example.py",
+            search='    print("Hello, World!")',
+            modified='    print("Hello, Universe!")',
         )
     ]
     result = extract_changes(content)


### PR DESCRIPTION
Gemini tends to close CDATA section with fences. This seems to happen only right before closing tag, which allow unambigous replacement of those fences.